### PR TITLE
Add a script to release binaries (from CI)

### DIFF
--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -8,6 +8,8 @@ REV=`git rev-parse HEAD`
 
 nix build -f release -o $TEMPDIR/$project
 
-tar --owner=serokell:1000 -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
+tar --owner=serokell:1000 --mode='u+rwX' -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
+
+hub release delete auto-release
 
 hub release create -a $TEMPDIR/release.tar.gz -m "Automatic build on $(date -I)" --prerelease auto-release

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -4,7 +4,7 @@ project=$(basename $(pwd))
 
 nix build -f release -o $project
 
-tar --owner=serokell:1000 -czf release.tar.gz $project
+tar --owner=serokell:1000 -czhf release.tar.gz $project
 
 if hub release | grep nightly
 then

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -13,4 +13,4 @@ else
     action=create
 fi
 
-hub release $action -a release.tar.gz -m "Nightly build on $(date -I)" --draft=true --prerelease nightly
+hub release $action -a release.tar.gz -m "Nightly build on $(date -I)" --prerelease nightly

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -4,12 +4,12 @@ project=$(basename $(pwd))
 
 TEMPDIR=`mktemp -d`
 
-REV=`git rev-parse HEAD`
-
 nix build -f release -o $TEMPDIR/$project
 
 tar --owner=serokell:1000 --mode='u+rwX' -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
 
 hub release delete auto-release
+
+git tag -d auto-release
 
 hub release create -a $TEMPDIR/release.tar.gz -m "Automatic build on $(date -I)" --prerelease auto-release

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p gitAndTools.hub git -i bash
+
+# Project name, inferred from repository name
 project=$(basename $(pwd))
 
+# The directory in which tarball will be created
 TEMPDIR=`mktemp -d`
 
+# Build release/default.nix
 nix build -f release -o $TEMPDIR/$project
 
+# Create a tarball with the result
 tar --owner=serokell:1000 --mode='u+rwX' -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
 
+# Delete release and tag
 hub release delete auto-release
-
 git tag -d auto-release
 
+# Create release
 hub release create -a $TEMPDIR/release.tar.gz -m "Automatic build on $(date -I)" --prerelease auto-release

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -10,6 +10,7 @@
 # 2. Run this script from CI on each commit to master.
 # 3. When you think it's time to make a real release, edit the auto release: change the tag, write a description, remove "pre-release" checkmark.
 
+set -euo pipefail
 
 # Project name, inferred from repository name
 project=$(basename $(pwd))

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p gitAndTools.hub -i bash
-nix build -f static.nix --out-link result-static
-cp -r result-static/bin .
-DATE=$(date -I)
+nix build -f release
+
+cp -r result/bin .
 tar --owner=serokell:1000 -czf release.tar.gz README.md LICENSE bin/*
+
 if hub release | grep nightly
 then
     action=edit
@@ -11,4 +12,4 @@ else
     action=create
 fi
 
-hub release $action -a release.tar.gz -m "Nightly build on $DATE" --draft=true --prerelease nightly
+hub release $action -a release.tar.gz -m "Nightly build on $(date -I)" --draft=true --prerelease nightly

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p gitAndTools.hub -i bash
+#!nix-shell -p gitAndTools.hub git -i bash
 project=$(basename $(pwd))
 
-nix build -f release -o $project
+TEMPDIR=`mktemp -d`
 
-tar --owner=serokell:1000 -czhf release.tar.gz $project
+REV=`git rev-parse HEAD`
 
-if hub release | grep nightly
-then
-    action=edit
-else
-    action=create
-fi
+nix build -f release -o $TEMPDIR/$project
 
-hub release $action -a release.tar.gz -m "Nightly build on $(date -I)" --prerelease nightly
+tar --owner=serokell:1000 -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
+
+hub release create -a $TEMPDIR/release.tar.gz -m "Automatic build on $(date -I)" --prerelease auto-release

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p gitAndTools.hub -i bash
-nix build -f release
+project=$(basename $(pwd))
 
-cp -r result/bin .
-tar --owner=serokell:1000 -czf release.tar.gz README.md LICENSE bin/*
+nix build -f release -o $project
+
+tar --owner=serokell:1000 -czf release.tar.gz $project
 
 if hub release | grep nightly
 then

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p gitAndTools.hub git -i bash
 
+# This script will create a new GitHub (pre-)release for the current repository with tag `auto-release`.
+# If such tag already exists, it will be overwritten.
+# It will automatically build `release/default.nix` and put its result into a tar archive that will be attached to the release.
+
+# Suggested usage:
+# 1. Make sure your repository has `release/default.nix` that produces whatever you want to release.
+# 2. Run this script from CI on each commit to master.
+# 3. When you think it's time to make a real release, edit the auto release: change the tag, write a description, remove "pre-release" checkmark.
+
+
 # Project name, inferred from repository name
 project=$(basename $(pwd))
 
@@ -8,14 +18,18 @@ project=$(basename $(pwd))
 TEMPDIR=`mktemp -d`
 
 # Build release/default.nix
-nix build -f release -o $TEMPDIR/$project
+nix-build release -o $TEMPDIR/$project
 
 # Create a tarball with the result
 tar --owner=serokell:1000 --mode='u+rwX' -czhf $TEMPDIR/release.tar.gz -C $TEMPDIR $project
 
-# Delete release and tag
+# Delete release
 hub release delete auto-release
-git tag -d auto-release
+
+# Update the tag
+git fetch # So that the script can be run from an arbitrary checkout
+git tag -f auto-release
+git push --force --tags
 
 # Create release
 hub release create -a $TEMPDIR/release.tar.gz -m "Automatic build on $(date -I)" --prerelease auto-release

--- a/scripts/release-static-binary.sh
+++ b/scripts/release-static-binary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p gitAndTools.hub -i bash
+nix build -f static.nix --out-link result-static
+cp -r result-static/bin .
+DATE=$(date -I)
+tar --owner=serokell:1000 -czf release.tar.gz README.md LICENSE bin/*
+if hub release | grep nightly
+then
+    action=edit
+else
+    action=create
+fi
+
+hub release $action -a release.tar.gz -m "Nightly build on $DATE" --draft=true --prerelease nightly


### PR DESCRIPTION
This is related to INT-111 (which is building static binaries for crossref-verifier),
it allows the built binaries to be published on github automatically from CI.