### PR TITLE
upload-daemon: fix concurrency, remove fmt, add arg parser

### DIFF
--- a/scripts/upload-daemon/default.nix
+++ b/scripts/upload-daemon/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, async, base, bytestring, fmt, network-simple
-, process, prometheus, stdenv, text
+, process, prometheus, stdenv, text, optparse-applicative
 }:
 mkDerivation {
   pname = "upload-daemon";
@@ -8,7 +8,8 @@ mkDerivation {
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
-    async base bytestring fmt network-simple process prometheus text
+    async base bytestring network-simple process prometheus text
+    optparse-applicative
   ];
   description = "Upload daemon for nix post-build-hook";
   license = stdenv.lib.licenses.mpl20;

--- a/scripts/upload-daemon/upload-daemon.cabal
+++ b/scripts/upload-daemon/upload-daemon.cabal
@@ -22,10 +22,10 @@ executable upload-daemon
                      , prometheus
                      , network-simple
                      , async
-                     , fmt
                      , text                     
                      , bytestring
                      , process
+                     , optparse-applicative
   -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -threaded


### PR DESCRIPTION
- add workers (2 by default)
- remove `fmt` (what is it even for)
- add argument parser instead of env var reading